### PR TITLE
Add the ast parser

### DIFF
--- a/create_ast.c
+++ b/create_ast.c
@@ -1,0 +1,69 @@
+#include "parser.h"
+
+t_ast *last_ast(t_ast *ast)
+{
+	while (ast && ast->next)
+		ast = ast->next;
+	return (ast);
+}
+
+void ast_add_back(t_ast **head, t_ast *new)
+{
+	if (!head || !new)
+		return;
+	while (*head)
+		head = &(*head)->next;
+	*head = new;
+}
+
+void ast_redirct_realloc(t_ast *ast)
+{
+	size_t	    buff_size;
+	t_redirect *buff;
+	size_t	    i;
+
+	buff_size = ast->redir_size * 2;
+	buff = ft_calloc(buff_size, sizeof(t_redirect));
+	i = 0;
+	while (i < ast->redir_size)
+	{
+		buff[i] = ast->redir[i];
+		i++;
+	}
+	ast->redir = buff;
+	ast->_buff_size = buff_size;
+}
+
+void ast_add_redirct(t_ast *ast, t_lexer *lexer)
+{
+	t_token token;
+	char   *target;
+
+	if (ast->_buff_size == ast->redir_size)
+		ast_redirct_realloc(ast);
+	token = lexer_next_token(lexer);
+	ast->redir[ast->redir_size].type = tok_kind_to_redir_type(token.kind);
+	token = lexer_peek_next_token(lexer);
+	if (token_is_word(token) == false)
+	{
+		printf(ERR_UNEXPECTED_TOK, alloc_token_str(token));
+		TODO("hanlde redirection errors");
+	}
+	target = lexer_next_zip_word(lexer);
+	ast->redir[ast->redir_size++].target = target;
+}
+
+t_ast *create_ast(t_lexer *lexer)
+{
+	t_ast *ast;
+
+	ast = NULL;
+	while (lexer_peek_next_token(lexer).kind)
+	{
+		ast_try_add_simple_cmd(&ast, lexer);
+		ast_try_add_connector(&ast, lexer);
+		ast_try_add_subshell(&ast, lexer);
+	}
+	return (ast);
+}
+

--- a/lexer.h
+++ b/lexer.h
@@ -1,6 +1,6 @@
 #ifndef _LEXER_H_
 # define _LEXER_H_
-# include "includes.h"
+# include "types.h"
 
 typedef enum
 {
@@ -49,5 +49,13 @@ t_token				lexer_next_token(t_lexer *l);
 const char			*token_kind_name(t_token_kind kind);
 void				print_token(t_token token);
 void	print_lexer_tokens(t_lexer *lexer);
+char *alloc_token_str(t_token token);
+bool token_is_word(t_token token);
+bool token_is_redir_op(t_token token);
+bool token_is_operator(t_token token);
+char *lexer_next_zip_word(t_lexer *lexer);
+bool next_token_is_joinable(t_lexer *lexer);
+t_redirect_type tok_kind_to_redir_type(t_token_kind kind);
+t_token lexer_peek_next_token(t_lexer *lexer);
 
 #endif /*_LEXER_H_ */

--- a/lexer_extra.c
+++ b/lexer_extra.c
@@ -1,0 +1,37 @@
+#include "parser.h"
+
+/**
+ * lexer_peek_next_token - Get the next token without moving the cursor
+ *
+ * @lexer: pointer to the lexer
+ * Return: next token
+ */
+t_token lexer_peek_next_token(t_lexer *lexer)
+{
+	t_token token;
+	size_t	cursor_location;
+
+	cursor_location = lexer->cursor;
+	token = lexer_next_token(lexer);
+	lexer->cursor = cursor_location;
+	return (token);
+}
+
+/**
+ */
+char *lexer_next_zip_word(t_lexer *lexer)
+{
+	char   *zip_word;
+	char   *tmp_zip_word;
+	t_token token;
+
+	token = lexer_next_token(lexer);
+	zip_word = alloc_token_str(token);
+	while (next_token_is_joinable(lexer))
+	{
+		token = lexer_next_token(lexer);
+		tmp_zip_word = alloc_token_str(token);
+		zip_word = ft_strjoin(zip_word, tmp_zip_word);
+	}
+	return (zip_word);
+}

--- a/lexer_tokens_utils.c
+++ b/lexer_tokens_utils.c
@@ -1,0 +1,45 @@
+#include "lexer.h"
+#include "main.h"
+
+bool token_is_word(t_token token)
+{
+	return (token.kind == TOKEN_DQ || token.kind == TOKEN_SQ ||
+		token.kind == TOKEN_WORD);
+}
+bool token_is_redir_op(t_token token)
+{
+	return (token.kind == TOKEN_OUT || token.kind == TOKEN_IN ||
+		token.kind == TOKEN_HEREDOC || token.kind == TOKEN_APPEND);
+}
+
+bool token_is_operator(t_token token)
+{
+	return (token.kind == TOKEN_PIPE || token.kind == TOKEN_AND ||
+		token.kind == TOKEN_OR);
+}
+
+bool next_token_is_joinable(t_lexer *lexer)
+{
+	t_token token;
+
+	token = lexer_peek_next_token(lexer);
+	if (token_is_word(token))
+		return (token.whitespace_before == false);
+	return (false);
+}
+
+t_redirect_type tok_kind_to_redir_type(t_token_kind kind)
+{
+	if (kind == TOKEN_OUT)
+		return (REDIR_TYPE_OUT);
+	else if (kind == TOKEN_IN)
+		return (REDIR_TYPE_IN);
+	else if (kind == TOKEN_APPEND)
+		return (REDIR_TYPE_APPEND);
+	else if (kind == TOKEN_HEREDOC)
+		return (REDIR_TYPE_HEREDOC);
+	else
+	{
+		UNREACHABLE("Undefind token kind!");
+	}
+}

--- a/main.c
+++ b/main.c
@@ -11,14 +11,21 @@
 /* ************************************************************************** */
 
 #include "main.h"
+#include "types.h"
+#include "print_ast.h"
+#include "parser.h"
 
-int	main(int ac, char **av)
+int	main(void)
 {
-	(void)(ac);
+	t_ast *ast;
+	char *line;
+	t_lexer lexer;
 
-	char **list = ft_split(av[1], ' ');
-	ft_gc_clear();
+	while ((line = readline("$ ")))
+	{
+		lexer = lexer_new(line, ft_strlen(line));
+		ast = create_ast(&lexer);
+		print_ast(ast);
+	}
 
-	(void)list;
-	return (EXIT_SUCCESS);
 }

--- a/parse_connector.c
+++ b/parse_connector.c
@@ -1,0 +1,34 @@
+#include "parser.h"
+
+t_ast *ast_try_add_connector(t_ast **ast_head, t_lexer *lexer)
+{
+	t_ast  *ast;
+	t_token token;
+
+	token = lexer_peek_next_token(lexer);
+	if (token.kind != TOKEN_PIPE && token.kind != TOKEN_OR &&
+	    token.kind != TOKEN_AND)
+		return (NULL);
+	if (!last_ast(*ast_head))
+	{
+		printf(ERR_UNEXPECTED_TOK, alloc_token_str(token));
+		UNIMPLEMENTED("Handle errors");
+	}
+	if (last_ast(*ast_head)->type != AST_SIMPLE_COMMAND && last_ast(*ast_head)->type != AST_SUBSHELL)
+	{
+		printf(ERR_UNEXPECTED_TOK, alloc_token_str(token));
+		UNIMPLEMENTED("Handle errors");
+	}
+	token = lexer_next_token(lexer);
+	ast = ft_calloc(1, sizeof(t_ast));
+	ast->next = NULL;
+	ast->type = AST_CONNECTOR;
+	if (token.kind == TOKEN_OR)
+		ast->connector = CONNECTOR_OR;
+	else if (token.kind == TOKEN_AND)
+		ast->connector = CONNECTOR_AND;
+	else if (token.kind == TOKEN_PIPE)
+		ast->connector = CONNECTOR_PIPE;
+	ast_add_back(ast_head, ast);
+	return (ast);
+}

--- a/parse_simple_cmd.c
+++ b/parse_simple_cmd.c
@@ -1,0 +1,72 @@
+#include "parser.h"
+
+void ast_simple_cmd_realloc(t_ast *ast)
+{
+	size_t buff_size;
+	char **buff;
+	size_t i;
+
+	buff_size = ast->simple_cmd.argc * 2;
+	buff = ft_calloc(buff_size, sizeof(char *));
+	i = 0;
+	while (i < ast->simple_cmd.argc)
+	{
+		buff[i] = ast->simple_cmd.argv[i];
+		i++;
+	}
+	ast->simple_cmd.argv = buff;
+	ast->simple_cmd._buff_size = buff_size;
+}
+
+void ast_simple_cmd_add_arg(t_ast *ast, t_lexer *lexer)
+{
+	char *arg;
+
+	if (ast->type != AST_SIMPLE_COMMAND)
+	{
+		UNREACHABLE("Wrong ast type!");
+		return;
+	}
+	if (ast->simple_cmd._buff_size == ast->simple_cmd.argc)
+		ast_simple_cmd_realloc(ast);
+	arg = lexer_next_zip_word(lexer);
+	ast->simple_cmd.argv[ast->simple_cmd.argc++] = arg;
+}
+
+t_ast *init_ast_simple_cmd(void)
+{
+	t_ast *ast;
+
+	ast = ft_calloc(1, sizeof(t_ast));
+	ast->type = AST_SIMPLE_COMMAND;
+	ft_bzero(&ast->simple_cmd, sizeof(t_simple_cmd));
+	ast->simple_cmd.argv = ft_calloc(ARRAY_INIT_SIZE, sizeof(char *));
+	ast->simple_cmd._buff_size = ARRAY_INIT_SIZE;
+	ast->redir_size = 0;
+	ast->redir = ft_calloc(ARRAY_INIT_SIZE, sizeof(t_redirect));
+	ast->_buff_size = ARRAY_INIT_SIZE;
+	return (ast);
+}
+
+t_ast *ast_try_add_simple_cmd(t_ast **ast_head, t_lexer *lexer)
+{
+	t_ast  *ast;
+	t_token token;
+
+	token = lexer_peek_next_token(lexer);
+	if (!token_is_word(token) && !token_is_redir_op(token))
+		return (NULL);
+	ast = init_ast_simple_cmd();
+	ast_add_back(ast_head, ast);
+	while (token.kind)
+	{
+		if (token_is_word(token))
+			ast_simple_cmd_add_arg(ast, lexer);
+		else if (token_is_redir_op(token))
+			ast_add_redirct(ast, lexer);
+		else
+			break;
+		token = lexer_peek_next_token(lexer);
+	}
+	return (ast);
+}

--- a/parse_subshell.c
+++ b/parse_subshell.c
@@ -1,0 +1,94 @@
+#include "parser.h"
+
+void skip_nested_parens(t_lexer *lexer)
+{
+	t_token token;
+	int	depth;
+
+	token = lexer_next_token(lexer);
+	depth = 1;
+	while (token.kind)
+	{
+		if (token.kind == TOKEN_OPAREN)
+			depth++;
+		else if (token.kind == TOKEN_CPAREN)
+			depth--;
+		if (token.kind == TOKEN_CPAREN && depth == 0)
+			break;
+		token = lexer_next_token(lexer);
+	}
+	if (depth > 0)
+	{
+		printf(ERR_UNEXPECTED_TOK, "(");
+		UNIMPLEMENTED("Handle unclosing parentheses errors");
+	}
+	else if (depth < 0)
+	{
+		printf(ERR_UNEXPECTED_TOK, ")");
+		UNIMPLEMENTED("Handle unclosing parentheses errors");
+	}
+}
+
+t_lexer subshell_new_lexer(t_lexer *lexer)
+{
+	size_t	cursor_loc;
+	t_lexer sub_lexer;
+	size_t lexer_size;
+
+	lexer_next_token(lexer); /* skip open parent */
+	cursor_loc = lexer->cursor;
+	skip_nested_parens(lexer);
+	lexer_size = lexer->cursor - cursor_loc - 1;
+	sub_lexer = lexer_new(&lexer->content[cursor_loc], lexer_size);
+	return (sub_lexer);
+}
+
+t_ast *init_ast_subshell(void)
+{
+	t_ast *ast;
+
+	ast = ft_calloc(1, sizeof(t_ast));
+	ast->type = AST_SUBSHELL;
+	ast->redir_size = 0;
+	ast->redir = ft_calloc(ARRAY_INIT_SIZE, sizeof(t_redirect));
+	ast->_buff_size = ARRAY_INIT_SIZE;
+	return (ast);
+}
+
+t_ast *ast_try_add_subshell(t_ast **ast_head, t_lexer *lexer)
+{
+	t_ast  *ast;
+	t_token token;
+	t_lexer sub_lexer;
+
+	token = lexer_peek_next_token(lexer);
+	if (token.kind == TOKEN_CPAREN)
+	{
+		printf(ERR_UNEXPECTED_TOK, ")");
+		TODO("Handle Errors\n");
+	}
+	if (token.kind != TOKEN_OPAREN)
+		return (NULL);
+	if (last_ast(*ast_head) && last_ast(*ast_head)->type != AST_CONNECTOR)
+	{
+		printf(ERR_UNEXPECTED_TOK, ")");
+		UNIMPLEMENTED("Syntax error\n");
+	}
+	ast = init_ast_subshell();
+	sub_lexer = subshell_new_lexer(lexer);
+	ast->subshell = create_ast(&sub_lexer);
+	if (ast->subshell == NULL)
+	{
+		printf(ERR_UNEXPECTED_TOK, ")");
+		UNIMPLEMENTED("Syntax error\n");
+	}
+	token = lexer_peek_next_token(lexer);
+	while (token_is_redir_op(token))
+	{
+		ast_add_redirct(ast, lexer);
+		token = lexer_peek_next_token(lexer);
+	}
+	ast_add_back(ast_head, ast);
+	return (ast);
+}
+

--- a/parser.h
+++ b/parser.h
@@ -1,0 +1,27 @@
+#include "main.h"
+#include "lexer.h"
+
+#define ARRAY_INIT_SIZE 16
+#define ERR_UNEXPECTED_TOK "msh: syntax error near unexpected token `%s'\n"
+
+/* parse_subshell.c */
+void skip_nested_parens(t_lexer *lexer);
+t_lexer subshell_new_lexer(t_lexer *lexer);
+t_ast *init_ast_subshell(void);
+t_ast *ast_try_add_subshell(t_ast **ast_head, t_lexer *lexer);
+
+/* parse_simple_cmd.c */
+t_ast *init_ast_simple_cmd(void);
+void ast_simple_cmd_realloc(t_ast *ast);
+void ast_simple_cmd_add_arg(t_ast *ast, t_lexer *lexer);
+t_ast *ast_try_add_simple_cmd(t_ast **ast_head, t_lexer *lexer);
+
+/* parse_connector.c */
+t_ast *ast_try_add_connector(t_ast **ast_head, t_lexer *lexer);
+
+/* create_ast.c */
+t_ast *create_ast(t_lexer *lexer);
+t_ast *last_ast(t_ast *ast);
+void ast_add_back(t_ast **head, t_ast *new);
+void ast_redirct_realloc(t_ast *ast);
+void ast_add_redirct(t_ast *ast, t_lexer *lexer);

--- a/print_ast.c
+++ b/print_ast.c
@@ -18,10 +18,10 @@ void	print_ast_simple_cmd(t_ast *ast, int indent)
 	print_ast_type(ast, indent++);
 	_tree_line_prefix(indent, true);
 	_tree_line_prefix(indent, false);
-	printf("────── %sARGC (%d):%s ", TEXT_UWHITE, ast->simple_cmd->argc,
+	printf("────── %sARGC (%d):%s ", TEXT_UWHITE, (int)ast->simple_cmd.argc,
 		TEXT_RESET);
-	while (i < (size_t)ast->simple_cmd->argc)
-		printf("%s ", ast->simple_cmd->argv[i++]);
+	while (i < (size_t)ast->simple_cmd.argc)
+		printf("%s ", ast->simple_cmd.argv[i++]);
 	printf("\n");
 	_tree_line_prefix(indent, false);
 	printf("────── %sI/O (%zu):%s ", TEXT_UWHITE, ast->redir_size, TEXT_RESET);

--- a/print_ast.c
+++ b/print_ast.c
@@ -1,4 +1,5 @@
 #include "print_ast.h"
+#include "includes.h"
 
 /**
  * print_ast_simple_cmd - print ast simple command, with its I/O redirections
@@ -10,7 +11,7 @@ void	print_ast_simple_cmd(t_ast *ast, int indent)
 {
 	size_t	i;
 
-	if (!ast || ast->type != AST_SIMPLE_COMMAND)
+	if (ast->type != AST_SIMPLE_COMMAND || !ast)
 	{
 		UNREACHABLE("takes only none-null ast of simple command type!");
 	}
@@ -18,10 +19,10 @@ void	print_ast_simple_cmd(t_ast *ast, int indent)
 	print_ast_type(ast, indent++);
 	_tree_line_prefix(indent, true);
 	_tree_line_prefix(indent, false);
-	printf("────── %sARGC (%d):%s ", TEXT_UWHITE, (int)ast->simple_cmd.argc,
+	printf("────── %sARGS (%ld):%s ", TEXT_UWHITE, ast->simple_cmd.argc,
 		TEXT_RESET);
 	while (i < (size_t)ast->simple_cmd.argc)
-		printf("%s ", ast->simple_cmd.argv[i++]);
+		printf("'%s' ", ast->simple_cmd.argv[i++]);
 	printf("\n");
 	_tree_line_prefix(indent, false);
 	printf("────── %sI/O (%zu):%s ", TEXT_UWHITE, ast->redir_size, TEXT_RESET);
@@ -63,16 +64,25 @@ void	print_ast_type(t_ast *ast, int indent)
  */
 void	print_ast_subshell(t_ast *ast, int indent)
 {
-	if (!ast || ast->type != AST_SUBSHELL)
+	if (ast->type != AST_SUBSHELL || !ast)
 	{
 		UNREACHABLE("takes only none-null ast of subshell type!");
 	}
 	print_ast_type(ast, indent++);
 	_tree_line_prefix(indent, true);
-	_print_ast_helper(ast->subshell, indent);
-	_print_tree_end_root(indent);
+	if (ast->subshell)
+	{
+		_print_ast_helper(ast->subshell, indent);
+		_print_tree_end_root(indent);
+	}
+	else
+	{
+		_tree_line_prefix(indent, false);
+		printf("────── %s EMPTY_SUBSHELL%s\n", TEXT_BRED, TEXT_RESET);
+		_tree_line_prefix(indent, true);
+	}
 	_tree_line_prefix(indent, false);
-	printf("────── %sI/O (%zu):%s ", TEXT_UWHITE, ast->redir_size, TEXT_RESET);
+	printf("────── %sSUBSHELL I/O (%zu):%s ", TEXT_UWHITE, ast->redir_size, TEXT_RESET);
 	print_ast_redirection(ast, indent);
 }
 
@@ -87,11 +97,13 @@ void	print_ast_redirection(t_ast *ast, int indent)
 {
 	size_t	i;
 
-	if (!ast || ast->type == AST_CONNECTOR)
+	if (ast->type == AST_CONNECTOR || !ast)
 	{
 		UNREACHABLE("None-null ast connector node doesn't have redirection!");
 	}
 	i = 0;
+	if (ast->redir_size == 0)
+		printf("(nil)");
 	while (i < ast->redir_size)
 	{
 		if (i % 2)

--- a/token_expand.c
+++ b/token_expand.c
@@ -1,0 +1,8 @@
+#include "lexer.h"
+#include "libft/libft.h"
+
+char *alloc_token_str(t_token token)
+{
+	/* NOTE: Expand will happen here */
+	return (ft_substr(token.text, 0, token.text_len));
+}

--- a/types.h
+++ b/types.h
@@ -58,7 +58,8 @@ typedef struct s_redirect
 typedef struct s_simple_cmd
 {
 	char				**argv;
-	int					argc;
+	size_t					argc;
+	size_t _buff_size;
 }						t_simple_cmd;
 
 /*
@@ -70,11 +71,12 @@ typedef struct s_ast
 	union
 	{
 		t_connector		connector;
-		t_simple_cmd	*simple_cmd;
+		t_simple_cmd	simple_cmd;
 		struct s_ast	*subshell;
 	};
 	t_redirect			*redir;
 	size_t			redir_size;
+	size_t _buff_size;
 	struct s_ast		*next;
 }						t_ast;
 


### PR DESCRIPTION
I added the `_buff_size` to keep track of the capacity of the dynamic array, to  know when a "relloac" is necessary
`ast` parser beta is officially finished, create it using `create_ast` function, and print it using the `print_ast` function

![image](https://github.com/user-attachments/assets/88bbb79a-4971-4d59-aa16-9f250dc9ffd6)

Check `main.c` to now how to user it!
