### PR TITLE
Feature/g collector

### DIFF
--- a/libft/ft_lstremove.c
+++ b/libft/ft_lstremove.c
@@ -1,0 +1,35 @@
+# include "./libft.h"
+# include <stdio.h>
+
+/**
+ * ft_ltsremove - removes a node from a linked-list
+ * @head: Head/ first node of the list
+ * @node: node to remove
+ */
+void	ft_lstremove(t_list **head, void *data, void (*del)(void *))
+{
+	t_list	*temp;
+	t_list	*next;
+
+	if (!head || !*head || !data)
+		return ;
+	if (data == (*head)->content)
+	{
+		del(data);
+		free(*head);
+		*head = NULL;
+		return ;
+	}
+	temp = *head;
+	while (temp)
+	{
+		next = temp->next;
+		if (next && next->content == data)
+		{
+			temp->next = next->next;
+			del(data);
+			free(next);
+		}
+		temp = temp->next;
+	}
+}

--- a/libft/libft.h
+++ b/libft/libft.h
@@ -77,6 +77,7 @@ void				ft_lstiter(t_list *lst, void (*f)(void *));
 bool	ft_lstismember(t_list *head, void *data);
 t_list				*ft_lstmap(t_list *l, void *(*f)(void *),
 						void (*d)(void *));
+void	ft_lstremove(t_list **head, void *data, void (*del)(void *));
 char	*xgc_strdup(const char *src);
 
 #endif

--- a/libft/memory.c
+++ b/libft/memory.c
@@ -1,22 +1,25 @@
 #include "./libft.h"
+# include "../includes.h"
 
 typedef enum s_act
 {
 	CLEAR,
 	INSERT,
-	REMOVE
+	REMOVE,
+	PRINT,
 }	t_act;
 
-/*static void	ft_gcprint(t_list *gc)*/
-/*{*/
-/*	printf("-------------\n");*/
-/*	while (gc)*/
-/*	{*/
-/*		printf("[%p]\n", gc->content);*/
-/*		gc = gc->next;*/
-/*	}*/
-/*	printf("-------------\n");*/
-/*}*/
+static void	debug(t_list *gc)
+{
+	printf("-------------\n");
+	while (gc)
+	{
+		printf("[%p]\n", gc->content);
+		gc = gc->next;
+	}
+	printf("-------------\n");
+}
+
 
 static void	ft_gc_act(void *addr, t_act action)
 {
@@ -36,7 +39,20 @@ static void	ft_gc_act(void *addr, t_act action)
 		ft_lstadd_back(&gc, gc_node);
 	}
 	else if (action == REMOVE)
-		ft_lstdelone(addr, free);
+		ft_lstremove(&gc, addr, free);
+	else if (action == PRINT)
+		debug(gc);
+}
+
+void	ft_gcprint(void)
+{
+	ft_gc_act(NULL, PRINT);
+}
+
+void	ft_gcadd_back(void *addr)
+{
+	if (addr)
+		ft_gc_act(addr, INSERT);
 }
 
 void	*ft_malloc(size_t	size, size_t unit)
@@ -48,12 +64,6 @@ void	*ft_malloc(size_t	size, size_t unit)
 	return (addr);
 }
 
-void	ft_gcadd_back(void *addr)
-{
-	if (addr)
-		ft_gc_act(addr, INSERT);
-}
-
 void	ft_gc_clear(void)
 {
 	ft_gc_act(NULL, CLEAR);
@@ -62,5 +72,18 @@ void	ft_gc_clear(void)
 void	ft_gc_remove(void *addr)
 {
 	ft_gc_act(addr, REMOVE);
+}
+
+void ft_gc_remove_ft_split(char **list)
+{
+	int	i;
+
+	i = 0;
+	while (list[i])
+	{
+		ft_gc_remove(list[i]);
+		i++;
+	}
+	ft_gc_remove(list);
 }
 

--- a/libft/memory.h
+++ b/libft/memory.h
@@ -6,4 +6,8 @@
 void	*ft_malloc(size_t	size, size_t unit);
 void	ft_gcadd_back(void *addr);
 void	ft_gc_clear(void);
+void ft_gc_remove_ft_split(char **list);
+void	ft_gc_remove(void *addr);
+/* For debuggin purposes */
+void	ft_gcprint(void);
 #endif /* MEMORY_H */


### PR DESCRIPTION
Added some options to remove unneeded blocks of memory instead of waiting for the **`ft_gc_clear()`** at the end of each loop:

- Implementing the function `ft_lstremove()` that takes a list and a content and removes the corresponding node.
- Adding a costum func to remove lists created using the `ft_split()`  (commonly used and wastes memory anyway).
- Tests for the feature will be found at **`tests/`** directory.